### PR TITLE
Improve delete confirmation dialog and add CSS for styling

### DIFF
--- a/TravisMovieRatings/Views/Shared/_Layout.cshtml
+++ b/TravisMovieRatings/Views/Shared/_Layout.cshtml
@@ -29,7 +29,7 @@
 
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/TravisMovieRatings.styles.css" asp-append-version="true" />
-
+    <link rel="stylesheet" href="~/css/Movies/confirmDeleteMovie.css" asp-append-version="true" />
 
     @RenderSection("head", false)   <!-- Allows views to import CSS files  -->
 </head>

--- a/TravisMovieRatings/wwwroot/css/Movies/confirmDeleteMovie.css
+++ b/TravisMovieRatings/wwwroot/css/Movies/confirmDeleteMovie.css
@@ -1,0 +1,8 @@
+﻿.movie-thumbnail {
+    width: 100px;
+    height: auto;
+}
+
+.warning-message-margin-top {
+    margin-top: 20px;
+}

--- a/TravisMovieRatings/wwwroot/js/confirmDeleteMovie.js
+++ b/TravisMovieRatings/wwwroot/js/confirmDeleteMovie.js
@@ -2,18 +2,17 @@
     e.preventDefault();
 
     Swal.fire({
-        title: 'Are you sure?',
+        title: 'Delete this from your collection?',
         html: `
-            <p>You are about to delete:</p>
-            <h3>${movieName}</h3>
-            <img src="${movieThumbnailUrl}" alt="Movie Thumbnail" style="width: 100px; height: auto;"/>
-            <p>This action cannot be undone!</p>
+            <h4>${movieName}</h4>
+            <img src="${movieThumbnailUrl}" alt="Movie Thumbnail" class="movie-thumbnail"/>
+            <p class="warning-message-margin-top">This can't be undone.</p>
         `,
         icon: 'warning',
         showCancelButton: true,
-        confirmButtonColor: '#3085d6',
-        cancelButtonColor: '#d33',
-        confirmButtonText: 'Yes, delete it!',
+        confirmButtonColor: '#d33',     // red confirm button
+        cancelButtonColor: '#3085d6',   // blue cancel button
+        confirmButtonText: 'Delete',
         focusCancel: true
     }).then((alertResult) => {
         if (alertResult.isConfirmed) {


### PR DESCRIPTION
- _Layout.cshtml: Added a link to import confirmDeleteMovie.css for styling the confirmation dialog.

- confirmDeleteMovie.css: Added styles for the movie thumbnail and warning message.

- confirmDeleteMovie.js:
  - Updated the title to "Delete this from your collection?" for a friendlier message that works for both movies and games.
  - Replaced inline styles with CSS classes for the thumbnail and the warning message.
  - Changed button colors to red for confirm and blue for cancel.
  - Simplified the warning message to "This can't be undone."