### PR TITLE
refactor(startup,routing): separate endpoint mapping from middleware …

### DIFF
--- a/MoviePicks.Api/Program.cs
+++ b/MoviePicks.Api/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Options;
-using MoviePicks.Api.Extensions;
+using MoviePicks.Api.Startup;
+using MoviePicks.Api.Routing;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -9,14 +10,12 @@ builder.Services.ConfigureServices(builder.Configuration, builder.Environment);
 
 var app = builder.Build();
 
-// Add Aspire telemetry configuration
-app.MapDefaultEndpoints();
-
 var logger = app.Services.GetRequiredService<ILogger<Program>>();
 
 try
 {
     app.ConfigureMiddleware();
+    app.MapEndpoints();
     app.Run();
 }
 catch (OptionsValidationException ex)

--- a/MoviePicks.Api/Routing/EndpointRouteBuilderExtensions.cs
+++ b/MoviePicks.Api/Routing/EndpointRouteBuilderExtensions.cs
@@ -1,0 +1,61 @@
+﻿namespace MoviePicks.Api.Routing;
+
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using System;
+
+public static class EndpointRouteBuilderExtensions
+{
+    public static void MapEndpoints(this WebApplication app)
+    {
+        MapApiEndpoints(app);
+        MapObservabilityEndpoints(app);
+
+        if (app.Environment.IsDevelopment())
+        {
+            MapDevelopmentExceptionEndpoint(app);
+            MapTestEndpoints(app);
+        }
+    }
+
+    private static void MapApiEndpoints(WebApplication app)
+    {
+        app.MapControllers();
+    }
+
+    private static void MapObservabilityEndpoints(WebApplication app)
+    {
+        // Add Aspire telemetry endpoints
+        app.MapDefaultEndpoints();
+    }
+
+    // Development-only error handler used by UseExceptionHandler to return detailed error responses.
+    private static void MapDevelopmentExceptionEndpoint(WebApplication app)
+    {
+        app.MapGet(ExceptionHandlingRoutes.DevelopmentException, async (HttpContext httpContext) =>
+        {
+            var exceptionFeature = httpContext.Features.Get<IExceptionHandlerFeature>();
+            var exception = exceptionFeature?.Error;
+
+            var logger = httpContext.RequestServices.GetRequiredService<ILogger<Program>>();
+            logger.LogError(exception, "Unhandled exception occurred in development.");
+
+            return Results.Problem(
+                detail: exception?.Message,
+                statusCode: StatusCodes.Status500InternalServerError,
+                title: "An error occurred");
+        });
+    }
+
+    // Theese endpoints are for testing and development only.
+    private static void MapTestEndpoints(WebApplication app)
+    {
+        app.MapGet("/test-exception", (HttpContext _) =>
+        {
+            throw new Exception("Test exception");
+            return Results.Problem(); // unreachable, but helps metadata
+        });
+
+        app.MapGet("/test-bad-status-code-handler/{statusCode}", (int statusCode) => Results.StatusCode(statusCode));
+    }
+}

--- a/MoviePicks.Api/Routing/ExceptionHandlingRoutes.cs
+++ b/MoviePicks.Api/Routing/ExceptionHandlingRoutes.cs
@@ -1,0 +1,6 @@
+﻿namespace MoviePicks.Api.Routing;
+
+public static class ExceptionHandlingRoutes
+{
+    public const string DevelopmentException = "/development-exception-handler";
+}

--- a/MoviePicks.Api/Startup/ServiceCollectionExtensions.cs
+++ b/MoviePicks.Api/Startup/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace MoviePicks.Api.Extensions;
+﻿namespace MoviePicks.Api.Startup;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;

--- a/MoviePicks.Api/Startup/WebApplicationExtensions.cs
+++ b/MoviePicks.Api/Startup/WebApplicationExtensions.cs
@@ -1,22 +1,16 @@
-﻿namespace MoviePicks.Api.Extensions;
+﻿namespace MoviePicks.Api.Startup;
 
-using Microsoft.AspNetCore.Diagnostics;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using System;
 using MoviePicks.Api.Models;
+using MoviePicks.Api.Routing;
 
 public static partial class WebApplicationExtensions
 {
-    private static readonly string DevExceptionHandlerEndpointPath = "/development-exception-handler";
-
     public static void ConfigureMiddleware(this WebApplication app)
     {
         // Configure the HTTP request pipeline.
         if (app.Environment.IsDevelopment())
         {
             ConfigureDevelopmentMiddleware(app);
-            ConfigureTestingEndpoints(app);
         }
         else
         {
@@ -46,44 +40,13 @@ public static partial class WebApplicationExtensions
         }
 
         app.UseAuthorization();
-
-        app.MapControllers();
     }
 
     private static void ConfigureDevelopmentMiddleware(WebApplication app)
     {
         app.UseSwagger();
         app.UseSwaggerUI();
-        app.UseExceptionHandler(DevExceptionHandlerEndpointPath); // Routes exceptions to the minimal API endpoint
-        ConfigureExceptionHandlingEndpoint(app);
-    }
-
-    // This minimal API endpoint returns the prepared ProblemDetails response when an exception occurs.
-    // This endpoint is only used in development mode.
-    private static void ConfigureExceptionHandlingEndpoint(WebApplication app)
-    {
-        // Custom error handling for development mode with detailed information and logging
-        app.MapGet(DevExceptionHandlerEndpointPath, async (HttpContext httpContext) =>
-          {
-            var exceptionFeature = httpContext.Features.Get<IExceptionHandlerFeature>();
-            var exception = exceptionFeature?.Error;
-
-            // Retrieve a logger instance using the built-in ASP.NET Core logging
-            var logger = httpContext.RequestServices.GetRequiredService<ILogger<Program>>();
-            logger.LogError(exception, "Unhandled exception occurred in development.");
-
-            var problemDetails = new ProblemDetails
-                  {
-                    Title = "An error occurred",
-                    Status = StatusCodes.Status500InternalServerError,
-                    Detail = exception?.Message // Detailed error information for development
-                  };
-
-            return Results.Problem(
-                detail: problemDetails.Detail,
-                title: problemDetails.Title,
-                statusCode: problemDetails.Status);
-                });
+        app.UseExceptionHandler(ExceptionHandlingRoutes.DevelopmentException); // Routes exceptions to the minimal API endpoint
     }
 
     private static void ConfigureProductionMiddleware(WebApplication app)
@@ -95,12 +58,5 @@ public static partial class WebApplicationExtensions
         // path is specified. This ExceptionHandlerMiddleware uses registered service
         // IProblemDetailsService to provide the ProblemDetails response.
         app.UseExceptionHandler();
-    }
-
-    private static void ConfigureTestingEndpoints(WebApplication app)
-    {
-        // The following minimal API endpoints are used for testing and development only.
-        app.MapGet("/test-exception", (HttpContext context) => throw new Exception("Test exception"));
-        app.MapGet("/test-bad-status-code-handler/{statusCode}", (int statusCode) => Results.StatusCode(statusCode));
     }
 }


### PR DESCRIPTION
…and centralize routing

- Introduce MapEndpoints() to consolidate all endpoint registrations
- Move endpoint definitions (API, observability, exception handling, test) into routing layer
- Centralize exception route via ExceptionHandlingRoutes
- Restrict routing concerns to EndpointRouteBuilderExtensions
- Simplify WebApplicationExtensions to focus solely on middleware configuration
- Rename Extensions folder to Startup to reflect its role in application initialization (invoked by Program.cs)
- Update Program.cs to use new composition structure

Result:
- Clear separation between middleware pipeline and endpoint routing
- Improved maintainability and discoverability of endpoints
- Better alignment with ASP.NET Core minimal hosting patterns