### PR TITLE
chore: migrate from Swagger/Swashbuckle to native OpenAPI and Scalar UI.

### DIFF
--- a/MoviePicks.Api/MoviePicks.Api.csproj
+++ b/MoviePicks.Api/MoviePicks.Api.csproj
@@ -12,12 +12,13 @@
     <None Remove="Controllers\Obsolete\**" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.14.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />

--- a/MoviePicks.Api/Properties/launchSettings.json
+++ b/MoviePicks.Api/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "scalar/v1",
       "applicationUrl": "http://localhost:5053",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -22,7 +22,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "scalar/v1",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/MoviePicks.Api/Routing/EndpointRouteBuilderExtensions.cs
+++ b/MoviePicks.Api/Routing/EndpointRouteBuilderExtensions.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
+using Scalar.AspNetCore;
 using System;
 
 public static class EndpointRouteBuilderExtensions
@@ -13,6 +14,8 @@ public static class EndpointRouteBuilderExtensions
 
         if (app.Environment.IsDevelopment())
         {
+            MapOpenApiDocumentation(app);
+
             MapDevelopmentExceptionEndpoint(app);
             MapTestEndpoints(app);
         }
@@ -27,6 +30,21 @@ public static class EndpointRouteBuilderExtensions
     {
         // Add Aspire telemetry endpoints
         app.MapDefaultEndpoints();
+    }
+
+    private static void MapOpenApiDocumentation(WebApplication app)
+    {
+        // Generates the OpenAPI JSON document that describes the API's endpoints and schemas.
+        app.MapOpenApi();
+
+        // Displays the interactive user interface that allows developers to
+        // browse and test the API using the generated OpenApi document.
+        app.MapScalarApiReference(options =>
+        {
+            options.WithTitle("Movie Picks API")
+                   .WithTheme(ScalarTheme.DeepSpace) // Modern dark/orange theme
+                   .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient);
+        });
     }
 
     // Development-only error handler used by UseExceptionHandler to return detailed error responses.

--- a/MoviePicks.Api/Startup/ServiceCollectionExtensions.cs
+++ b/MoviePicks.Api/Startup/ServiceCollectionExtensions.cs
@@ -22,9 +22,8 @@ public static partial class ServiceCollectionExtensions
 
         services.AddControllers();
 
-        // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
         services.AddEndpointsApiExplorer();
-        services.AddSwaggerGen();
+        services.AddOpenApi();
 
         services.AddScoped<IUnitOfWork, UnitOfWork>();
         services.AddScoped<IMoviesService, MoviesService>();

--- a/MoviePicks.Api/Startup/WebApplicationExtensions.cs
+++ b/MoviePicks.Api/Startup/WebApplicationExtensions.cs
@@ -2,6 +2,7 @@
 
 using MoviePicks.Api.Models;
 using MoviePicks.Api.Routing;
+using Scalar.AspNetCore;
 
 public static partial class WebApplicationExtensions
 {
@@ -44,8 +45,6 @@ public static partial class WebApplicationExtensions
 
     private static void ConfigureDevelopmentMiddleware(WebApplication app)
     {
-        app.UseSwagger();
-        app.UseSwaggerUI();
         app.UseExceptionHandler(ExceptionHandlingRoutes.DevelopmentException); // Routes exceptions to the minimal API endpoint
     }
 


### PR DESCRIPTION
Replaces the Swashbuckle library with native Microsoft.AspNetCore.OpenApi to align with .NET 10 standards. This updates the API documentation from legacy Swagger UI to the modern Scalar interactive reference.