### PR TITLE
Implement movie search with 500ms debounce to protect OMDB API limits

### DIFF
--- a/MoviePicks.Web/Views/Movies/Create.cshtml
+++ b/MoviePicks.Web/Views/Movies/Create.cshtml
@@ -43,7 +43,7 @@
             <div class="search-element">
                 <h4>Find movie by title</h4>
                 <div id="error-loading-movies-by-title" class="text-info"></div>
-                <input type="text" id="search-text" placeholder="Enter Movie Title" onkeyup="searchMovies()" onclick="searchMovies();" />
+                <input type="text" id="search-text" placeholder="Enter Movie Title"/>
                 <div id="movie-items">
                 </div>
             </div>

--- a/MoviePicks.Web/wwwroot/js/MoviesCreate.js
+++ b/MoviePicks.Web/wwwroot/js/MoviesCreate.js
@@ -262,3 +262,23 @@ async function searchMovies() {
         selectedMovieRenderer.switchToSearchMode();
     }
 }
+
+function debounce(func, delay) {
+    let timeoutId;
+
+    return function (...args) {
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+        }
+
+        timeoutId = setTimeout(() => {
+            func.apply(this, args);
+        }, delay);
+    };
+}
+
+// Using a long 500ms delay to avoid chatty API calls while user is typing
+// because OMDB API has a very low free tier limit of 1000 calls per day.
+const delayTimeInMilliseconds = 500;
+const debouncedSearch = debounce(searchMovies, delayTimeInMilliseconds);
+movieSearchBox.addEventListener("input", debouncedSearch);


### PR DESCRIPTION
- Implement a 500ms debounce delay to movie search to stay within 1,000 call/day free tier limit.
- Decouple search logic from HTML to support debounced event handling.