### PR TITLE
feat(data): make a user's movie ratings optional

### DIFF
--- a/MoviePicks.Api/Migrations/20260420213147_MakeRatingNullable.Designer.cs
+++ b/MoviePicks.Api/Migrations/20260420213147_MakeRatingNullable.Designer.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MoviePicks.Api.Models;
 
@@ -10,9 +11,11 @@ using MoviePicks.Api.Models;
 namespace MoviePicks.Api.Migrations
 {
     [DbContext(typeof(DbMovieContext))]
-    partial class DbMovieContextModelSnapshot : ModelSnapshot
+    [Migration("20260420213147_MakeRatingNullable")]
+    partial class MakeRatingNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MoviePicks.Api/Migrations/20260420213147_MakeRatingNullable.cs
+++ b/MoviePicks.Api/Migrations/20260420213147_MakeRatingNullable.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MoviePicks.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeRatingNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Rating",
+                table: "Movies",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Rating",
+                table: "Movies",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+        }
+    }
+}

--- a/MoviePicks.Api/Models/MovieViewModel.cs
+++ b/MoviePicks.Api/Models/MovieViewModel.cs
@@ -11,9 +11,6 @@ public class MovieViewModel
     public MovieViewModel()
     {
         this.ImdbId = EMPTY_STRING;
-        this.Rating = 0;
-        this.ReviewHeading = EMPTY_STRING;
-        this.ReviewComments = EMPTY_STRING;
         this.Title = EMPTY_STRING;
         this.Year = EMPTY_STRING;
         this.Rated = EMPTY_STRING;
@@ -43,7 +40,7 @@ public class MovieViewModel
 
     [Range(1, 10)]
     [Display(Name = "Personal Rating")]
-    public int Rating { get; set; }
+    public int? Rating { get; set; }
 
     [Display(Name = "Review Heading")]
     [DataType(DataType.Text)]

--- a/MoviePicks.Api/MoviePicks.Api.csproj
+++ b/MoviePicks.Api/MoviePicks.Api.csproj
@@ -13,6 +13,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+    <PackageReference Include="NuGet.Packaging" Version="7.3.1" />
+    <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.14.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/MoviePicks.Contracts/MovieBase.cs
+++ b/MoviePicks.Contracts/MovieBase.cs
@@ -16,7 +16,7 @@ public class MovieBase : IIdentifiable
     // This will go into a separate Review class when multiple users are allowed because then a movie can have multiple reviews.
 
     [Display(Name = "Rating")]
-    public int Rating { get; set; }
+    public int? Rating { get; set; }
 
     [Display(Name = "Review Heading")]
     [DataType(DataType.Text)]

--- a/MoviePicks.Web/Models/MovieViewModel.cs
+++ b/MoviePicks.Web/Models/MovieViewModel.cs
@@ -11,9 +11,6 @@ public class MovieViewModel
     public MovieViewModel()
     {
         this.ImdbId = EmptyString;
-        this.Rating = 0;
-        this.ReviewHeading = EmptyString;
-        this.ReviewComments = EmptyString;
         this.Title = EmptyString;
         this.Year = EmptyString;
         this.Rated = EmptyString;
@@ -43,7 +40,7 @@ public class MovieViewModel
 
     [Range(1, 10)]
     [Display(Name = "Personal Rating")]
-    public int Rating { get; set; }
+    public int? Rating { get; set; }
 
     [Display(Name = "Review Heading")]
     [DataType(DataType.Text)]

--- a/MoviePicks.Web/MoviePicks.Web.csproj
+++ b/MoviePicks.Web/MoviePicks.Web.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="NuGet.Packaging" Version="7.3.1" />
+    <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">


### PR DESCRIPTION
Refactor the movie data model to allow movies to exist without a personal rating. This supports the workflow of adding movies to a user's library  without requiring a user to add a movie rating.

- Update MovieBase contract and ViewModels to use nullable int for Rating.
- Add EF Core migration to alter 'Movies.Rating' column to allow NULL.
- Upgrade NuGet packages to resolve security vulnerabilities that were preventing database migration.